### PR TITLE
fix: handle subscription plan errors without error_description field

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3commas-openapi"]
+	path = 3commas-openapi
+	url = https://github.com/recomma/3commas-openapi.git

--- a/gen.go
+++ b/gen.go
@@ -1,4 +1,4 @@
-//go:generate go tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config=oapi.yaml ../3commas/openapi.yaml
+//go:generate go tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config=oapi.yaml 3commas-openapi/3commas/openapi.yaml
 //go:generate go run error_helpers_gen.go -input ./threecommas/openapi.gen.go -output ./threecommas/apierr_gen.go -package threecommas
 //go:generate go run options_generator.go -input ./threecommas/openapi.gen.go -output ./threecommas/options_gen.go -package threecommas
 //go:generate go tool golang.org/x/tools/cmd/goimports -w ./threecommas/options_gen.go

--- a/threecommas/apierr_gen.go
+++ b/threecommas/apierr_gen.go
@@ -996,13 +996,13 @@ func (r *ValidateAuthenticationResponse) GetJSON504() *GatewayTimeout {
 
 type APIErrorResponses interface {
 	StatusCode() int
-	GetJSON400() *BadRequest
-	GetJSON403() *Forbidden
-	GetJSON418() *IPAutoBanned
-	GetJSON500() *InternalServerError
 	GetJSON401() *Unauthorized
+	GetJSON403() *Forbidden
 	GetJSON404() *NotFound
+	GetJSON418() *IPAutoBanned
 	GetJSON429() *RateLimitExceeded
 	GetJSON504() *GatewayTimeout
+	GetJSON400() *BadRequest
+	GetJSON500() *InternalServerError
 }
 

--- a/threecommas/apierr_gen.go
+++ b/threecommas/apierr_gen.go
@@ -996,13 +996,13 @@ func (r *ValidateAuthenticationResponse) GetJSON504() *GatewayTimeout {
 
 type APIErrorResponses interface {
 	StatusCode() int
-	GetJSON401() *Unauthorized
-	GetJSON403() *Forbidden
 	GetJSON404() *NotFound
 	GetJSON418() *IPAutoBanned
 	GetJSON429() *RateLimitExceeded
+	GetJSON500() *InternalServerError
 	GetJSON504() *GatewayTimeout
 	GetJSON400() *BadRequest
-	GetJSON500() *InternalServerError
+	GetJSON401() *Unauthorized
+	GetJSON403() *Forbidden
 }
 

--- a/threecommas/testdata/TestListBots_Subscription_not_active.yaml
+++ b/threecommas/testdata/TestListBots_Subscription_not_active.yaml
@@ -1,0 +1,52 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.3commas.io
+        url: https://api.3commas.io/public/api/ver1/bots
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: 143
+        body: '{"error":"The request type ''read'' is not available with your current subscription plan. Please upgrade your plan to use this type of request."}'
+        headers:
+            Access-Control-Allow-Credentials:
+                - "true"
+            Access-Control-Allow-Headers:
+                - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,Signature,Apikey,Forced-Mode
+            Access-Control-Allow-Methods:
+                - GET, PUT, POST, DELETE, PATCH, OPTIONS
+            Access-Control-Allow-Origin:
+                - '*'
+            Access-Control-Max-Age:
+                - "1728000"
+            Cache-Control:
+                - no-cache
+            Cf-Cache-Status:
+                - DYNAMIC
+            Cf-Ray:
+                - 99c6726f8c2ae567-TXL
+            Content-Length:
+                - "143"
+            Content-Type:
+                - application/json
+            Date:
+                - Mon, 10 Nov 2025 15:05:15 GMT
+            Server:
+                - cloudflare
+            Strict-Transport-Security:
+                - max-age=0
+            X-Request-Id:
+                - fe6fc5de037a1adbb7a9d6eedb512996
+            X-Runtime:
+                - "0.125455"
+        status: 429 Too Many Requests
+        code: 429
+        duration: 267.506041ms

--- a/threecommas/threecommas.go
+++ b/threecommas/threecommas.go
@@ -173,8 +173,10 @@ type APIError struct {
 
 // Error implements the error interface.
 func (e *APIError) Error() string {
-	// You can customize this however you like.
-	return fmt.Sprintf("API error %d: %s", e.StatusCode, *e.ErrorPayload.ErrorDescription)
+	if e.ErrorPayload.ErrorDescription != nil {
+		return fmt.Sprintf("API error %d: %s", e.StatusCode, *e.ErrorPayload.ErrorDescription)
+	}
+	return fmt.Sprintf("API error %d: %s", e.StatusCode, e.ErrorPayload.Error)
 }
 
 func (e *ErrorResponse) String() string {

--- a/threecommas/threecommas_test.go
+++ b/threecommas/threecommas_test.go
@@ -108,8 +108,9 @@ func TestListBots(t *testing.T) {
 		},
 		{
 			// Error method: runtime error: invalid memory address or nil pointer dereference) Error: The request type 'read' is not available with your current subscription plan. Please upgrade your plan to use this type of request.
-			name:   "Subscription not active",
-			config: config,
+			name:    "Subscription not active",
+			config:  config,
+			wantErr: "API error 429: The request type 'read' is not available with your current subscription plan. Please upgrade your plan to use this type of request.",
 		},
 	}
 

--- a/threecommas/threecommas_test.go
+++ b/threecommas/threecommas_test.go
@@ -106,6 +106,11 @@ func TestListBots(t *testing.T) {
 			}(),
 			record: false,
 		},
+		{
+			// Error method: runtime error: invalid memory address or nil pointer dereference) Error: The request type 'read' is not available with your current subscription plan. Please upgrade your plan to use this type of request.
+			name:   "Subscription not active",
+			config: config,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
Fixed a nil pointer dereference panic that occurred when the API returns error responses without an `error_description` field, particularly for subscription plan limitation errors.

## Problem
When the 3Commas API returns a 429 error for subscription plan limitations, the response only contains the `error` field without the optional `error_description` field:

```json
{
  "error": "The request type 'read' is not available with your current subscription plan. Please upgrade your plan to use this type of request."
}
```

The SDK's error handling code always attempted to dereference ErrorDescription, causing a panic:

```
runtime error: invalid memory address or nil pointer dereference
```

## Changes
### SDK Fix
 - Updated APIError.Error() method to check if ErrorDescription is nil before dereferencing
 - Falls back to the Error field when ErrorDescription is not present
 - Ensures robust error handling for all API error responses

### OpenAPI Spec Enhancement
 - Updated RateLimitExceeded response description to clarify it covers both rate limiting and subscription plan limitations
 - Added examples for both traditional rate limit errors and subscription plan limitation errors

### Testing
 - Added test case TestListBots/Subscription_not_active to verify the fix
 - Test validates proper error message formatting without panic

### Impact
 - Bug Fix: Eliminates panic when handling subscription plan limitation errors
 - Better Error Messages: Users now see clear error messages for subscription issues
 - Improved Documentation: OpenAPI spec better reflects actual API behavior