### PR TITLE
ratelimit: switch to fixed window

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -86,8 +86,10 @@ client, err := threecommas.New3CommasClient(
 ```
 
 If not specified, the SDK defaults to `PlanExpert` (120 req/min). The rate limiter:
-- Proactively prevents 429 (rate limit) errors using token bucket algorithm
-- Automatically handles 429 responses with backoff
+- Uses fixed-window rate limiting aligned to clock boundaries (matching 3Commas API behavior)
+- Allows bursts within the same time window (e.g., all 5 requests in 2 seconds is fine for Starter)
+- Proactively prevents 429 (rate limit) errors before they occur
+- Automatically handles 429 responses with backoff if limits are exceeded
 - Respects `Retry-After` headers from the server
 - Protects against IP auto-ban (418 responses) with 10-minute cooldown
 

--- a/threecommas/ratelimit_test.go
+++ b/threecommas/ratelimit_test.go
@@ -133,11 +133,11 @@ func TestDefaultPlanTier(t *testing.T) {
 	// Just verify the client was created successfully
 }
 
-func TestGlobalLimiterForTier(t *testing.T) {
+func TestTierLimiterForPlan(t *testing.T) {
 	tests := []struct {
 		name          string
 		tier          PlanTier
-		expectedBurst int
+		expectedLimit int
 	}{
 		{"Starter", PlanStarter, 5},
 		{"Pro", PlanPro, 50},
@@ -146,9 +146,10 @@ func TestGlobalLimiterForTier(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			limiter := globalLimiterForTier(tt.tier)
+			limiter := tierLimiterForPlan(tt.tier)
 			require.NotNil(t, limiter)
-			require.Equal(t, tt.expectedBurst, limiter.Burst())
+			require.Equal(t, tt.expectedLimit, limiter.limit)
+			require.Equal(t, time.Minute, limiter.windowSize)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixed rate limiter implementation to prevent 429 errors by replacing token bucket algorithm with fixed-window rate limiting that matches 3commas API behavior.

## Problem

The SDK was getting frequent 429 (Too Many Requests) errors despite having client-side rate limiting. Two issues were identified:

1. **Token bucket vs Fixed-window mismatch**: The previous implementation used `golang.org/x/time/rate` (token bucket algorithm) which continuously refills tokens. This doesn't match 3commas API's fixed-window rate limiting that resets at clock boundaries (e.g., 12:30:00, 12:31:00).

   With token bucket and PlanStarter (5/min), you could make 5 requests immediately, then earn additional tokens through gradual refills, resulting in ~10 requests within various 60-second sliding windows - exceeding the API's strict 5/minute limit.

2. **429 handler only blocked routes, not tier limiter**: When a 429 was received and matched a specific route, only that route was blocked. The tier limiter (account-wide subscription limit) wasn't blocked, causing cascading 429 errors across other endpoints.

## Solution

- Implemented custom `fixedWindowLimiter` that aligns to clock boundaries using `time.Truncate()`
- Windows reset at fixed times matching 3commas API behavior (minute boundaries for tier limits, 10-second boundaries for smart_trades)
- Allows bursts within the same window (e.g., all 5 requests in 2 seconds is acceptable for Starter tier)
- Fixed 429 handler to always block the tier limiter (not just individual routes)
- Renamed "global" to "tier" throughout for clarity
- Removed `golang.org/x/time/rate` dependency
- Updated README documentation to reflect fixed-window behavior

## Testing

All existing tests pass. Rate limiting tests confirm proper enforcement of tier limits with window-aligned behavior.