### PR TITLE
feat: restore request editor capability via WithClientOption

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -93,6 +93,40 @@ If not specified, the SDK defaults to `PlanExpert` (120 req/min). The rate limit
 - Respects `Retry-After` headers from the server
 - Protects against IP auto-ban (418 responses) with 10-minute cooldown
 
+## Middleware and Request Customization
+
+The SDK supports custom middleware for logging, monitoring, and request modification through `WithClientOption`:
+
+```go
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/recomma/3commas-sdk-go/threecommas"
+)
+
+// Custom request logger
+requestLogger := func(ctx context.Context, req *http.Request) error {
+	log.Printf("Making request: %s %s", req.Method, req.URL.Path)
+	return nil
+}
+
+client, err := threecommas.New3CommasClient(
+	threecommas.WithAPIKey("your-api-key"),
+	threecommas.WithPrivatePEM(privateKey),
+	threecommas.WithClientOption(
+		threecommas.WithRequestEditorFn(requestLogger),
+	),
+)
+```
+
+Multiple middleware can be chained, and they execute in order before the RSA authentication signer. This allows you to:
+- Log all HTTP requests and responses
+- Add custom headers or modify requests
+- Integrate with OpenTelemetry or other observability tools
+- Implement custom retry logic or circuit breakers
+
 ## Authentication
 
 This SDK uses RSA signature-based authentication with your API key and a PEM-encoded private key. Every request is signed using your private key per 3Commas API requirements.
@@ -135,6 +169,7 @@ if err := threecommas.GetErrorFromResponse(resp); err != nil {
 * Proper error parsing with descriptive messages
 * Support for typed request/response structs
 * Functional options pattern for clean, flexible configuration
+* Middleware support for logging, monitoring, and request customization
 * VCR-based integration tests using `go-vcr`
 
 ## Testing

--- a/examples/with_logging.go
+++ b/examples/with_logging.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/recomma/3commas-sdk-go/threecommas"
+)
+
+func main() {
+	privateKey, err := os.ReadFile("private.pem")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Custom request logger
+	requestLogger := func(ctx context.Context, req *http.Request) error {
+		log.Printf("Making request: %s %s", req.Method, req.URL.Path)
+		return nil
+	}
+
+	client, err := threecommas.New3CommasClient(
+		threecommas.WithAPIKey(os.Getenv("THREECOMMAS_API_KEY")),
+		threecommas.WithPrivatePEM(privateKey),
+		threecommas.WithPlanTier(threecommas.PlanPro),
+		// Add custom request editor for logging
+		threecommas.WithClientOption(
+			threecommas.WithRequestEditorFn(requestLogger),
+		),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// List bots - the request logger will log each request
+	bots, err := client.ListBots(
+		context.Background(),
+		threecommas.WithLimitForListBots(10),
+	)
+	if err != nil {
+		log.Fatalf("failed to list bots: %v", err)
+	}
+
+	fmt.Printf("Found %d bots\n", len(bots))
+}

--- a/threecommas/client_option_test.go
+++ b/threecommas/client_option_test.go
@@ -1,0 +1,65 @@
+package threecommas
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithClientOption demonstrates that users can now pass through
+// ClientOptions like WithRequestEditorFn for logging/modifying requests.
+func TestWithClientOption(t *testing.T) {
+	var capturedRequests []*http.Request
+
+	// Custom request editor to capture/log requests
+	requestLogger := func(ctx context.Context, req *http.Request) error {
+		capturedRequests = append(capturedRequests, req)
+		t.Logf("Request: %s %s", req.Method, req.URL.Path)
+		return nil
+	}
+
+	client, err := New3CommasClient(
+		WithAPIKey("test-key"),
+		WithPrivatePEM([]byte(fakeKey)),
+		WithClientOption(WithRequestEditorFn(requestLogger)),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	// Verify the client was created with our custom request editor
+	require.NotNil(t, client.ClientWithResponses)
+
+	// The request editor should be stored in clientOptions
+	require.Len(t, client.clientOptions, 1, "expected one client option")
+}
+
+// TestMultipleClientOptions verifies that multiple ClientOptions can be chained.
+func TestMultipleClientOptions(t *testing.T) {
+	var requestCount int
+
+	editor1 := func(ctx context.Context, req *http.Request) error {
+		requestCount++
+		req.Header.Set("X-Custom-Header-1", "value1")
+		return nil
+	}
+
+	editor2 := func(ctx context.Context, req *http.Request) error {
+		requestCount++
+		req.Header.Set("X-Custom-Header-2", "value2")
+		return nil
+	}
+
+	client, err := New3CommasClient(
+		WithAPIKey("test-key"),
+		WithPrivatePEM([]byte(fakeKey)),
+		WithClientOption(WithRequestEditorFn(editor1)),
+		WithClientOption(WithRequestEditorFn(editor2)),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	// Verify multiple client options were stored
+	require.Len(t, client.clientOptions, 2, "expected two client options")
+}


### PR DESCRIPTION
## Summary

Restores the ability to pass `WithRequestEditorFn` and other oapi-codegen `ClientOption` functions for HTTP middleware, logging, and request customization.

## Problem

The functional options refactor (commit 49f57b1) removed the ability to pass `ClientOption` functions directly to `New3CommasClient`. Users could no longer use `WithRequestEditorFn` to log or modify HTTP requests before they were sent.

## Solution

Refactored `ThreeCommasClient` to store configuration fields directly on the struct instead of using a separate internal `clientConfig` type. This allows `ThreeCommasClientOption` to operate on the client itself and enables pass-through of oapi-codegen `ClientOption` functions.

### Key Changes

- **Moved config fields to `ThreeCommasClient` struct**: `baseURL`, `apiKey`, `privatePEM`, `planTier`, `httpClient`, and new `clientOptions []ClientOption`
- **Added `WithClientOption()`**: Wrapper function that accepts `ClientOption` and stores them for pass-through
- **Request editor ordering**: User-provided request editors execute before the RSA authentication signer, enabling proper logging of requests before signing

### Architecture Benefits

This design enables future middleware additions like:
- `WithLogger(*slog.Logger)` for structured logging
- `WithOpenTelemetry(tracer)` for distributed tracing
- `WithMetrics(registry)` for observability
- Any custom `RequestEditorFn` for headers, logging, or request modification